### PR TITLE
FIX Evaluate input as a string

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Validate branch exists
       shell: bash
-      if: inputs.validate_branch
+      if: ${{ inputs.validate_branch == 'true' }}
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
         BRANCH: ${{ inputs.branch }}


### PR DESCRIPTION
The [validate_branch](https://github.com/silverstripe/gha-trigger-ci/blob/1/action.yml#L8) input we added to gha-trigger-ci doesn't seem like it's being evaluated as a boolean

In [this job](https://github.com/silverstripe/silverstripe-mfa/actions/runs/5921653334/job/16054489328#step:2:1571) (and others) you can see the `validate_branch: false` input being passed in, yet the block where the "Could not find branch pulls/5/update-js-1692588828" is being triggered from is still being run, despite that there's an `if: inputs.validate_branch`

The [official docs](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution) which say that `if` conditionals are automatically evaluated as expressions meaning you can omit the `${{}}` - an expressions will cast values to strings, so the `false` input boolean is being cast to a `"false"` string which passes the truthy test

In this PR I've wrapped the expression in `${{ }}` even though it doesn't need to be there, simply because we use it everywhere else so for consistency and clarify I think it's better to include it
