### PR TITLE
FIX Only send API request if a ci file was found

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,6 +72,7 @@ runs:
         fi
 
     - name: Send API request
+      if: ${{ steps.find-workflow.outputs.filename }}
       shell: bash
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/421

Fixes https://github.com/silverstripe/startup-theme/actions/runs/15768326459/job/44448746165 (broken merge-up because cannot trigger ci)

I haven't directly tested this, though am assuming this will worked based on https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions "GitHub performs loose equality comparisons." - meaning that if the ouput variable was not set, then this check will return something falsey and won't run the step